### PR TITLE
Generate full codebase from prompt

### DIFF
--- a/vibe-ui/src/trpc/routers/project.ts
+++ b/vibe-ui/src/trpc/routers/project.ts
@@ -817,13 +817,15 @@ export const projectRouter = createTRPCRouter({
             'tsconfig.json'
           ];
           
-          // Filter to only essential files or limit to 15 files max
+          // Filter to prioritize essential files first but do NOT truncate the list.
+          // This allows Lovable to generate the complete project structure as designed,
+          // while still ensuring we keep only relevant paths (pages/components/utils/etc.).
           fileStructure = fileStructure.filter(file => 
             essentialFiles.includes(file) || 
             file.includes('components/') ||
             file.includes('lib/') ||
             file.includes('utils/')
-          ).slice(0, 15);
+          );
           
         } catch (structureError) {
           console.error('File structure generation failed:', structureError);


### PR DESCRIPTION
Remove the 15-file cap on project generation to ensure the full codebase is generated as per the design specification.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e15d1205-4a53-4b05-bffb-65ff1e9ef4c3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e15d1205-4a53-4b05-bffb-65ff1e9ef4c3)